### PR TITLE
#83 Fixed product category layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10335,8 +10335,8 @@ background: #96bb7c;
 }
 
 .category-icon {
-  width: 200px;
-  height: 200px;
+  width: 250px;
+  height: auto;
   object-fit: cover;
   border-radius: 95%;
   transition: border 0.05s ease;
@@ -10348,4 +10348,47 @@ background: #96bb7c;
 
 .category-icon.unselected {
   border: none;
+}
+
+.category-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    width: 100%;
+}
+
+.category-item {
+    flex: 0 0 auto;
+    max-width: calc(20% - 1rem);
+    min-width: 150px;
+    margin-bottom: 1rem;
+}
+
+/* Mobile styles */
+@media (max-width: 768px) {
+  .category-container {
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none; /* Firefox */
+      -ms-overflow-style: none; /* IE and Edge */
+      padding-bottom: 1rem;
+      justify-content: flex-start;
+  }
+
+  .category-container::-webkit-scrollbar {
+      display: none; /* Chrome, Safari, Opera */
+  }
+
+  .category-item {
+      flex: 0 0 auto;
+      width: auto;
+      margin-right: 1rem;
+      margin-bottom: 0;
+  }
+
+  .category-item:last-child {
+      margin-right: 0;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -398,39 +398,35 @@
 				<div class="spinner-border" role="status"></div>
 			</div>
 			<div class="portfolio-wrapper">
-				<div class="d-flex align-items-center justify-content-evenly mb-5 py-md-3">
-					<div class="filter-wrap">
-						<div class="filter ml-auto d-flex justify-content-between" id="filters">
-							<div
-								class="category-item text-center mx-3"
-								v-for="(item, index) in store.category"
-								:key="item.id"
-								@click="showProductByCategory(index)"
-								style="cursor: pointer;"
-							>
-								<!-- Category Image -->
-								<img
-									v-if="item.category_icon"
-									:src="'data:image/jpeg;base64,' + item.category_icon"
-									alt="Category Icon"
-									class="category-icon img-fluid mb-2"
-									:class="{
-										selected: store.selectedCategory === item.name,
-										unselected: store.selectedCategory !== item.name
-									  }"
-								/>
-								<img
-									v-else
-									src="/images/item/no_product_img.png"
-									alt="Default Category Image"
-									class="category-icon img-fluid mb-2"
-									:class="{
-										selected: store.selectedCategory === item.name,
-										unselected: store.selectedCategory !== item.name
-									  }"
-								/>
-							</div>
-						</div>
+				<div class="category-container" id="filters">
+					<div
+						class="category-item"
+						v-for="(item, index) in store.category"
+						:key="item.id"
+						@click="showProductByCategory(index)"
+						style="cursor: pointer;"
+					>
+						<!-- Category Image -->
+						<img
+							v-if="item.category_icon"
+							:src="'data:image/jpeg;base64,' + item.category_icon"
+							alt="Category Icon"
+							class="category-icon img-fluid"
+							:class="{
+								selected: store.selectedCategory === item.name,
+								unselected: store.selectedCategory !== item.name
+								}"
+						/>
+						<img
+							v-else
+							src="/images/item/no_product_img.png"
+							alt="Default Category Image"
+							class="category-icon img-fluid mb-2"
+							:class="{
+								selected: store.selectedCategory === item.name,
+								unselected: store.selectedCategory !== item.name
+								}"
+						/>
 					</div>
 				</div>
 				<div id="posts" class="row d-flex">


### PR DESCRIPTION
Added:
- Wrapping to product category in web to only allow 5 icon per row, additional category will move down a row.
- Wrapping to product category in mobile to make all icon to be contained in a single scrollable row.


Product Category on web:
![image](https://github.com/user-attachments/assets/b7eb38b5-ba98-49e7-bc43-8012c963d4c3)

Product Category on mobile:
![image](https://github.com/user-attachments/assets/efeb466c-7961-477f-b789-bc8d258e43a1)


Video:

https://github.com/user-attachments/assets/b32c2aea-43d9-4a08-ac96-2a084bda0fa0

